### PR TITLE
Helpers for Elm

### DIFF
--- a/dist/elm/ES/UI/Color.elm
+++ b/dist/elm/ES/UI/Color.elm
@@ -1,4 +1,4 @@
-module ES.UI.Color exposing (Color, black, blue, green, grey, orange, purple, red, teal, transparent, white, yellow)
+module ES.UI.Color exposing (Color, black, blue, familyName, green, grey, orange, purple, red, teal, transparent, white, yellow)
 
 -- This is generated! Don't update manually!
 
@@ -25,76 +25,219 @@ transparent =
 
 
 teal =
-    { dark = Color.rgb255 16 128 139 -- #10808b
-    , base = Color.rgb255 20 161 174 -- #14a1ae
-    , light = Color.rgb255 0 195 201 -- #00c3c9
-    , lighter = Color.rgb255 102 219 223 -- #66dbdf
-    , lightest = Color.rgb255 218 245 247 -- #daf5f7
+    { dark = Color.rgb 0.06 0.5 0.55 -- #10808B
+    , base = Color.rgb 0.08 0.63 0.68 -- #14A1AE
+    , light = Color.rgb 0.0 0.76 0.79 -- #00C3C9
+    , lighter = Color.rgb 0.4 0.86 0.87 -- #66DBDF
+    , lightest = Color.rgb 0.85 0.96 0.97 -- #DAF5F7
     }
 
 
 green =
-    { dark = Color.rgb255 83 139 0 -- #538b00
-    , base = Color.rgb255 104 174 0 -- #68ae00
-    , light = Color.rgb255 147 213 49 -- #93d531
-    , lighter = Color.rgb255 190 230 131 -- #bee683
-    , lightest = Color.rgb255 221 240 193 -- #ddf0c1
+    { dark = Color.rgb 0.33 0.55 0.0 -- #538B00
+    , base = Color.rgb 0.41 0.68 0.0 -- #68AE00
+    , light = Color.rgb 0.58 0.84 0.19 -- #93D531
+    , lighter = Color.rgb 0.75 0.9 0.51 -- #BEE683
+    , lightest = Color.rgb 0.87 0.94 0.76 -- #DDF0C1
     }
 
 
 yellow =
-    { dark = Color.rgb255 193 143 8 -- #c18f08
-    , base = Color.rgb255 242 179 11 -- #f2b30b
-    , light = Color.rgb255 255 208 84 -- #ffd054
-    , lighter = Color.rgb255 255 227 152 -- #ffe398
-    , lightest = Color.rgb255 255 241 205 -- #fff1cd
+    { dark = Color.rgb 0.76 0.56 0.03 -- #C18F08
+    , base = Color.rgb 0.95 0.7 0.04 -- #F2B30B
+    , light = Color.rgb 1.0 0.82 0.33 -- #FFD054
+    , lighter = Color.rgb 1.0 0.89 0.6 -- #FFE398
+    , lightest = Color.rgb 1.0 0.95 0.8 -- #FFF1CD
     }
 
 
 orange =
-    { dark = Color.rgb255 194 82 0 -- #c25200
-    , base = Color.rgb255 243 103 0 -- #f36700
-    , light = Color.rgb255 255 143 60 -- #ff8f3c
-    , lighter = Color.rgb255 255 188 138 -- #ffbc8a
-    , lightest = Color.rgb255 255 232 214 -- #ffe8d6
+    { dark = Color.rgb 0.76 0.32 0.0 -- #C25200
+    , base = Color.rgb 0.95 0.4 0.0 -- #F36700
+    , light = Color.rgb 1.0 0.56 0.24 -- #FF8F3C
+    , lighter = Color.rgb 1.0 0.74 0.54 -- #FFBC8A
+    , lightest = Color.rgb 1.0 0.91 0.84 -- #FFE8D6
     }
 
 
 red =
-    { dark = Color.rgb255 180 56 56 -- #b43838
-    , base = Color.rgb255 225 71 71 -- #e14747
-    , light = Color.rgb255 255 104 104 -- #ff6868
-    , lighter = Color.rgb255 255 164 164 -- #ffa4a4
-    , lightest = Color.rgb255 255 215 215 -- #ffd7d7
+    { dark = Color.rgb 0.71 0.22 0.22 -- #B43838
+    , base = Color.rgb 0.88 0.28 0.28 -- #E14747
+    , light = Color.rgb 1.0 0.41 0.41 -- #FF6868
+    , lighter = Color.rgb 1.0 0.64 0.64 -- #FFA4A4
+    , lightest = Color.rgb 1.0 0.84 0.84 -- #FFD7D7
     }
 
 
 purple =
-    { dark = Color.rgb255 116 62 147 -- #743e93
-    , base = Color.rgb255 145 78 184 -- #914eb8
-    , light = Color.rgb255 204 126 238 -- #cc7eee
-    , lighter = Color.rgb255 224 178 245 -- #e0b2f5
-    , lightest = Color.rgb255 248 237 255 -- #f8edff
+    { dark = Color.rgb 0.45 0.24 0.58 -- #743E93
+    , base = Color.rgb 0.57 0.31 0.72 -- #914EB8
+    , light = Color.rgb 0.8 0.49 0.93 -- #CC7EEE
+    , lighter = Color.rgb 0.88 0.7 0.96 -- #E0B2F5
+    , lightest = Color.rgb 0.97 0.93 1.0 -- #F8EDFF
     }
 
 
 blue =
-    { dark = Color.rgb255 10 83 155 -- #0a539b
-    , base = Color.rgb255 13 104 194 -- #0d68c2
-    , light = Color.rgb255 71 144 215 -- #4790d7
-    , lighter = Color.rgb255 145 188 231 -- #91bce7
-    , lightest = Color.rgb255 224 240 255 -- #e0f0ff
+    { dark = Color.rgb 0.04 0.33 0.61 -- #0A539B
+    , base = Color.rgb 0.05 0.41 0.76 -- #0D68C2
+    , light = Color.rgb 0.28 0.56 0.84 -- #4790D7
+    , lighter = Color.rgb 0.57 0.74 0.91 -- #91BCE7
+    , lightest = Color.rgb 0.88 0.94 1.0 -- #E0F0FF
     }
 
 
 grey =
-    { x90 = Color.rgb255 26 26 26 -- #1a1a1a
-    , x80 = Color.rgb255 51 51 51 -- #333333
-    , x70 = Color.rgb255 77 77 77 -- #4d4d4d
-    , x60 = Color.rgb255 102 102 102 -- #666666
-    , x50 = Color.rgb255 128 128 128 -- #808080
-    , x40 = Color.rgb255 153 153 153 -- #999999
-    , x30 = Color.rgb255 179 179 179 -- #b3b3b3
-    , x20 = Color.rgb255 204 204 204 -- #cccccc
-    , x10 = Color.rgb255 229 229 229 -- #e5e5e5
+    { x90 = Color.rgb 0.1 0.1 0.1 -- #1A1A1A
+    , x80 = Color.rgb 0.2 0.2 0.2 -- #333333
+    , x70 = Color.rgb 0.3 0.3 0.3 -- #4D4D4D
+    , x60 = Color.rgb 0.4 0.4 0.4 -- #666666
+    , x50 = Color.rgb 0.5 0.5 0.5 -- #808080
+    , x40 = Color.rgb 0.6 0.6 0.6 -- #999999
+    , x30 = Color.rgb 0.7 0.7 0.7 -- #B3B3B3
+    , x20 = Color.rgb 0.8 0.8 0.8 -- #CCCCCC
+    , x10 = Color.rgb 0.9 0.9 0.9 -- #E5E5E5
     }
+
+
+familyName : Color -> String
+familyName color =
+    let
+        { r, g, b } =
+            Color.toRgba
+    in
+    case ( r, g, b ) of
+        ( 0.06, 0.5, 0.55 ) ->
+            "teal"
+
+        ( 0.08, 0.63, 0.68 ) ->
+            "teal"
+
+        ( 0.0, 0.76, 0.79 ) ->
+            "teal"
+
+        ( 0.4, 0.86, 0.87 ) ->
+            "teal"
+
+        ( 0.85, 0.96, 0.97 ) ->
+            "teal"
+
+        ( 0.33, 0.55, 0.0 ) ->
+            "green"
+
+        ( 0.41, 0.68, 0.0 ) ->
+            "green"
+
+        ( 0.58, 0.84, 0.19 ) ->
+            "green"
+
+        ( 0.75, 0.9, 0.51 ) ->
+            "green"
+
+        ( 0.87, 0.94, 0.76 ) ->
+            "green"
+
+        ( 0.76, 0.56, 0.03 ) ->
+            "yellow"
+
+        ( 0.95, 0.7, 0.04 ) ->
+            "yellow"
+
+        ( 1.0, 0.82, 0.33 ) ->
+            "yellow"
+
+        ( 1.0, 0.89, 0.6 ) ->
+            "yellow"
+
+        ( 1.0, 0.95, 0.8 ) ->
+            "yellow"
+
+        ( 0.76, 0.32, 0.0 ) ->
+            "orange"
+
+        ( 0.95, 0.4, 0.0 ) ->
+            "orange"
+
+        ( 1.0, 0.56, 0.24 ) ->
+            "orange"
+
+        ( 1.0, 0.74, 0.54 ) ->
+            "orange"
+
+        ( 1.0, 0.91, 0.84 ) ->
+            "orange"
+
+        ( 0.71, 0.22, 0.22 ) ->
+            "red"
+
+        ( 0.88, 0.28, 0.28 ) ->
+            "red"
+
+        ( 1.0, 0.41, 0.41 ) ->
+            "red"
+
+        ( 1.0, 0.64, 0.64 ) ->
+            "red"
+
+        ( 1.0, 0.84, 0.84 ) ->
+            "red"
+
+        ( 0.45, 0.24, 0.58 ) ->
+            "purple"
+
+        ( 0.57, 0.31, 0.72 ) ->
+            "purple"
+
+        ( 0.8, 0.49, 0.93 ) ->
+            "purple"
+
+        ( 0.88, 0.7, 0.96 ) ->
+            "purple"
+
+        ( 0.97, 0.93, 1.0 ) ->
+            "purple"
+
+        ( 0.04, 0.33, 0.61 ) ->
+            "blue"
+
+        ( 0.05, 0.41, 0.76 ) ->
+            "blue"
+
+        ( 0.28, 0.56, 0.84 ) ->
+            "blue"
+
+        ( 0.57, 0.74, 0.91 ) ->
+            "blue"
+
+        ( 0.88, 0.94, 1.0 ) ->
+            "blue"
+
+        ( 0.1, 0.1, 0.1 ) ->
+            "grey"
+
+        ( 0.2, 0.2, 0.2 ) ->
+            "grey"
+
+        ( 0.3, 0.3, 0.3 ) ->
+            "grey"
+
+        ( 0.4, 0.4, 0.4 ) ->
+            "grey"
+
+        ( 0.5, 0.5, 0.5 ) ->
+            "grey"
+
+        ( 0.6, 0.6, 0.6 ) ->
+            "grey"
+
+        ( 0.7, 0.7, 0.7 ) ->
+            "grey"
+
+        ( 0.8, 0.8, 0.8 ) ->
+            "grey"
+
+        ( 0.9, 0.9, 0.9 ) ->
+            "grey"
+
+        _ ->
+            "unknown"

--- a/dist/elm/ES/UI/Color.elm
+++ b/dist/elm/ES/UI/Color.elm
@@ -100,144 +100,144 @@ grey =
     }
 
 
-familyName : Color -> String
-familyName color =
+identify : Color -> { family : String, shade : String, hex : String }
+identify color =
     let
         { r, g, b } =
-            Color.toRgba
+            Color.toRgba color
     in
     case ( r, g, b ) of
         ( 0.06, 0.5, 0.55 ) ->
-            "teal"
+            { family = "teal", shade = "dark", hex = "#10808B" }
 
         ( 0.08, 0.63, 0.68 ) ->
-            "teal"
+            { family = "teal", shade = "base", hex = "#14A1AE" }
 
         ( 0.0, 0.76, 0.79 ) ->
-            "teal"
+            { family = "teal", shade = "light", hex = "#00C3C9" }
 
         ( 0.4, 0.86, 0.87 ) ->
-            "teal"
+            { family = "teal", shade = "lighter", hex = "#66DBDF" }
 
         ( 0.85, 0.96, 0.97 ) ->
-            "teal"
+            { family = "teal", shade = "lightest", hex = "#DAF5F7" }
 
         ( 0.33, 0.55, 0.0 ) ->
-            "green"
+            { family = "green", shade = "dark", hex = "#538B00" }
 
         ( 0.41, 0.68, 0.0 ) ->
-            "green"
+            { family = "green", shade = "base", hex = "#68AE00" }
 
         ( 0.58, 0.84, 0.19 ) ->
-            "green"
+            { family = "green", shade = "light", hex = "#93D531" }
 
         ( 0.75, 0.9, 0.51 ) ->
-            "green"
+            { family = "green", shade = "lighter", hex = "#BEE683" }
 
         ( 0.87, 0.94, 0.76 ) ->
-            "green"
+            { family = "green", shade = "lightest", hex = "#DDF0C1" }
 
         ( 0.76, 0.56, 0.03 ) ->
-            "yellow"
+            { family = "yellow", shade = "dark", hex = "#C18F08" }
 
         ( 0.95, 0.7, 0.04 ) ->
-            "yellow"
+            { family = "yellow", shade = "base", hex = "#F2B30B" }
 
         ( 1.0, 0.82, 0.33 ) ->
-            "yellow"
+            { family = "yellow", shade = "light", hex = "#FFD054" }
 
         ( 1.0, 0.89, 0.6 ) ->
-            "yellow"
+            { family = "yellow", shade = "lighter", hex = "#FFE398" }
 
         ( 1.0, 0.95, 0.8 ) ->
-            "yellow"
+            { family = "yellow", shade = "lightest", hex = "#FFF1CD" }
 
         ( 0.76, 0.32, 0.0 ) ->
-            "orange"
+            { family = "orange", shade = "dark", hex = "#C25200" }
 
         ( 0.95, 0.4, 0.0 ) ->
-            "orange"
+            { family = "orange", shade = "base", hex = "#F36700" }
 
         ( 1.0, 0.56, 0.24 ) ->
-            "orange"
+            { family = "orange", shade = "light", hex = "#FF8F3C" }
 
         ( 1.0, 0.74, 0.54 ) ->
-            "orange"
+            { family = "orange", shade = "lighter", hex = "#FFBC8A" }
 
         ( 1.0, 0.91, 0.84 ) ->
-            "orange"
+            { family = "orange", shade = "lightest", hex = "#FFE8D6" }
 
         ( 0.71, 0.22, 0.22 ) ->
-            "red"
+            { family = "red", shade = "dark", hex = "#B43838" }
 
         ( 0.88, 0.28, 0.28 ) ->
-            "red"
+            { family = "red", shade = "base", hex = "#E14747" }
 
         ( 1.0, 0.41, 0.41 ) ->
-            "red"
+            { family = "red", shade = "light", hex = "#FF6868" }
 
         ( 1.0, 0.64, 0.64 ) ->
-            "red"
+            { family = "red", shade = "lighter", hex = "#FFA4A4" }
 
         ( 1.0, 0.84, 0.84 ) ->
-            "red"
+            { family = "red", shade = "lightest", hex = "#FFD7D7" }
 
         ( 0.45, 0.24, 0.58 ) ->
-            "purple"
+            { family = "purple", shade = "dark", hex = "#743E93" }
 
         ( 0.57, 0.31, 0.72 ) ->
-            "purple"
+            { family = "purple", shade = "base", hex = "#914EB8" }
 
         ( 0.8, 0.49, 0.93 ) ->
-            "purple"
+            { family = "purple", shade = "light", hex = "#CC7EEE" }
 
         ( 0.88, 0.7, 0.96 ) ->
-            "purple"
+            { family = "purple", shade = "lighter", hex = "#E0B2F5" }
 
         ( 0.97, 0.93, 1.0 ) ->
-            "purple"
+            { family = "purple", shade = "lightest", hex = "#F8EDFF" }
 
         ( 0.04, 0.33, 0.61 ) ->
-            "blue"
+            { family = "blue", shade = "dark", hex = "#0A539B" }
 
         ( 0.05, 0.41, 0.76 ) ->
-            "blue"
+            { family = "blue", shade = "base", hex = "#0D68C2" }
 
         ( 0.28, 0.56, 0.84 ) ->
-            "blue"
+            { family = "blue", shade = "light", hex = "#4790D7" }
 
         ( 0.57, 0.74, 0.91 ) ->
-            "blue"
+            { family = "blue", shade = "lighter", hex = "#91BCE7" }
 
         ( 0.88, 0.94, 1.0 ) ->
-            "blue"
+            { family = "blue", shade = "lightest", hex = "#E0F0FF" }
 
         ( 0.1, 0.1, 0.1 ) ->
-            "grey"
+            { family = "grey", shade = "90", hex = "#1A1A1A" }
 
         ( 0.2, 0.2, 0.2 ) ->
-            "grey"
+            { family = "grey", shade = "80", hex = "#333333" }
 
         ( 0.3, 0.3, 0.3 ) ->
-            "grey"
+            { family = "grey", shade = "70", hex = "#4D4D4D" }
 
         ( 0.4, 0.4, 0.4 ) ->
-            "grey"
+            { family = "grey", shade = "60", hex = "#666666" }
 
         ( 0.5, 0.5, 0.5 ) ->
-            "grey"
+            { family = "grey", shade = "50", hex = "#808080" }
 
         ( 0.6, 0.6, 0.6 ) ->
-            "grey"
+            { family = "grey", shade = "40", hex = "#999999" }
 
         ( 0.7, 0.7, 0.7 ) ->
-            "grey"
+            { family = "grey", shade = "30", hex = "#B3B3B3" }
 
         ( 0.8, 0.8, 0.8 ) ->
-            "grey"
+            { family = "grey", shade = "20", hex = "#CCCCCC" }
 
         ( 0.9, 0.9, 0.9 ) ->
-            "grey"
+            { family = "grey", shade = "10", hex = "#E5E5E5" }
 
         _ ->
             "unknown"

--- a/generate_colors.rb
+++ b/generate_colors.rb
@@ -15,6 +15,10 @@ class ColorGenerator
       [r, g, b].map(&transform).join(sep)
     end
 
+    def join_intensity(sep = ", ")
+      self.join(sep) { |item| (item / 255.0).round(2) }
+    end
+
     def hex
       sprintf("#%02x%02x%02x", r, g, b)
     end

--- a/tmpl/elm/ES/UI/Color.elm.erb
+++ b/tmpl/elm/ES/UI/Color.elm.erb
@@ -1,4 +1,4 @@
-module ES.UI.Color exposing (Color, black, white, transparent, <%= colors_hash.keys.join ", " %>)
+module ES.UI.Color exposing (Color, black, white, transparent, familyName, <%= colors_hash.keys.join ", " %>)
 
 -- <%= GENERATED_BLURB %>
 
@@ -29,7 +29,26 @@ transparent =
   <% shades.each_with_index do |(shade, hex), i| %>
     <% sep = i == 0 ? "{" : "," %>
     <% rgb = RGB.from_hex(hex) %>
-    <%= sep %> <%= as_elm_name(shade) %> = Color.rgb255 <%= rgb.join(' ') %> -- <%= rgb.hex %>
+    <%= sep %> <%= as_elm_name(shade) %> = Color.rgb <%= rgb.join_intensity(' ') %> -- <%= hex %>
   <% end %>
   }
 <% end %>
+
+
+familyName : Color -> String
+familyName color =
+  let
+    { r, g, b } =
+      Color.toRgba color
+  in
+  case ( r, g, b ) of
+<% colors_hash.each do |family, shades| %>
+  <% shades.each_with_index do |(shade, hex), i| %>
+    <% rgb = RGB.from_hex(hex) %>
+    (<%= rgb.join_intensity(", ") %>) ->
+      "<%= family %>"
+  <% end %>
+<% end %>
+
+    _ ->
+      "unknown"

--- a/tmpl/elm/ES/UI/Color.elm.erb
+++ b/tmpl/elm/ES/UI/Color.elm.erb
@@ -35,8 +35,8 @@ transparent =
 <% end %>
 
 
-familyName : Color -> String
-familyName color =
+identify : Color -> { family : String, shade : String, hex : String }
+identify color =
   let
     { r, g, b } =
       Color.toRgba color
@@ -46,7 +46,7 @@ familyName color =
   <% shades.each_with_index do |(shade, hex), i| %>
     <% rgb = RGB.from_hex(hex) %>
     (<%= rgb.join_intensity(", ") %>) ->
-      "<%= family %>"
+      { family = "<%= family %>", shade = "<%= shade %>", hex = "<%= hex %>" }
   <% end %>
 <% end %>
 


### PR DESCRIPTION
identify function:
- family
- shade
- hex

Thought: should we wrap `Color` with our own type (e.g. `alias ColorMeta = { color, family, shade, hex }`)? Most of this lookup can go away if we use actual records, albeit with slightly duplicated info.